### PR TITLE
Improve Redis error handling

### DIFF
--- a/src/SHAutomation.Core/AutomationElements/Window.cs
+++ b/src/SHAutomation.Core/AutomationElements/Window.cs
@@ -47,7 +47,7 @@ namespace SHAutomation.Core.AutomationElements
         /// </summary>
         public Window(FrameworkAutomationElementBase frameworkAutomationElement, ILoggingService loggingService, string pathToConfigFile) : base(frameworkAutomationElement)
         {
-            CacheService = new CacheService(pathToConfigFile);
+            CacheService = new CacheService(pathToConfigFile, loggingService);
 
             if (loggingService == null)
                 _loggingService = new LoggingService();

--- a/src/SHAutomation.Core/Caching/CacheService.cs
+++ b/src/SHAutomation.Core/Caching/CacheService.cs
@@ -52,7 +52,7 @@ namespace SHAutomation.Core.Caching
         {
             if (_usingRedis)
             {
-                if (_database != null)
+                if (_database == null)
                 {
                     try
                     {

--- a/test/SHAutomation.Core.Tests/Integration/XPathTests.cs
+++ b/test/SHAutomation.Core.Tests/Integration/XPathTests.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SHAutomation.Core.AutomationElements;
 using SHAutomation.Core.Caching;
+using SHAutomation.Core.Logging;
 using SHAutomation.Core.StaticClasses;
 using SHAutomation.Core.Tests.Common;
 using StackExchange.Redis;
@@ -239,8 +240,12 @@ namespace SHAutomation.Core.Tests.Integration
         public void XPathKeyReturnedSavesAsNormalTestNameWhenBranchNameNotNumericFormat_GenerateCacheKey_BeTrue()
         {
 
+            var loggingServiceMock = new Mock<ILoggingService>();
+            loggingServiceMock.Setup(x => x.Error(It.IsAny<Exception>()));
+            loggingServiceMock.Setup(x => x.Error(It.IsAny<string>()));
+
             string currentVariable = Environment.GetEnvironmentVariable("Build_SourceBranchName");
-            var cache = new CacheService(Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var cache = new CacheService(Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"), loggingServiceMock.Object);
             Environment.SetEnvironmentVariable("Build_SourceBranchName", "master");
             string output = cache.GenerateCacheKey(TestContext.TestName);
             output.Should().Be(TestContext.TestName);
@@ -252,9 +257,12 @@ namespace SHAutomation.Core.Tests.Integration
         [TestMethod]
         public void XPathKeyReturnedAsNormalTestWhenNoBranchVariable_GenerateCacheKey_BeTrue()
         {
+            var loggingServiceMock = new Mock<ILoggingService>();
+            loggingServiceMock.Setup(x => x.Error(It.IsAny<Exception>()));
+            loggingServiceMock.Setup(x => x.Error(It.IsAny<string>()));
 
             string currentVariable = Environment.GetEnvironmentVariable("Build_SourceBranchName");
-            var cache = new CacheService(Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var cache = new CacheService(Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"), loggingServiceMock.Object);
             Environment.SetEnvironmentVariable("Build_SourceBranchName", string.Empty);
             string output = cache.GenerateCacheKey(TestContext.TestName);
             output.Should().Be(TestContext.TestName);
@@ -263,9 +271,13 @@ namespace SHAutomation.Core.Tests.Integration
         [TestMethod]
         public void XPathKeyReturnedWithIterationWhenIterationBranchAvailable_GenerateCacheKey_BeTrue()
         {
+            var loggingServiceMock = new Mock<ILoggingService>();
+            loggingServiceMock.Setup(x => x.Error(It.IsAny<Exception>()));
+            loggingServiceMock.Setup(x => x.Error(It.IsAny<string>()));
+
             Environment.SetEnvironmentVariable("BranchMatchRegex", @"\d\.\d\d");
             string currentVariable = Environment.GetEnvironmentVariable("Build_SourceBranchName");
-            var cache = new CacheService(Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var cache = new CacheService(Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"), loggingServiceMock.Object);
             Environment.SetEnvironmentVariable("Build_SourceBranchName", "8.24");
             string output = cache.GenerateCacheKey(TestContext.TestName);
             output.Should().Be(TestContext.TestName + "_8.24");


### PR DESCRIPTION
Added a retry when attempting to GetDatabase and a `RedisTimeoutException` is thrown. Cut down the calls to GetDatabase so if GetCache value was successful and `_database` was set that same database object will be reused when calling `SetCacheValue`.