### PR TITLE
Added ability to set expiration on Redis keys

### DIFF
--- a/src/SHAutomation.Core/AutomationElements/Window.XPath.cs
+++ b/src/SHAutomation.Core/AutomationElements/Window.XPath.cs
@@ -33,18 +33,11 @@ namespace SHAutomation.Core.AutomationElements
 
             var cacheKey = CacheService.GenerateCacheKey(testName);
 
-            try
-            {
-                _loggingService.Info($"Attempting to find cache member with key {testName}");
 
-                _xpathGetContent = CacheService.GetCacheValue(cacheKey, testName);
-            }
-            catch (RedisTimeoutException ex)
-            {
-                _loggingService.Info(ex.Message);
-                _loggingService.Info("Redis timed out getting xpath so retrying");
-                _xpathGetContent = CacheService.GetCacheValue(cacheKey, testName);
-            }
+            _loggingService.Info($"Attempting to find cache member with key {testName}");
+
+            _xpathGetContent = CacheService.GetCacheValue(cacheKey, testName);
+
 
             if (!string.IsNullOrEmpty(_xpathGetContent))
             {
@@ -80,16 +73,9 @@ namespace SHAutomation.Core.AutomationElements
                 {
                     _loggingService.Info("Saving XPaths to cache");
 
-                    try
-                    {
-                        CacheService.SetCacheValue(cacheKey, output);
-                    }
-                    catch (RedisConnectionException ex)
-                    {
-                        _loggingService.Error(ex.Message);
 
-                        CacheService.SetCacheValue(cacheKey, output);
-                    }
+                    CacheService.SetCacheValue(cacheKey, output);
+
                 }
                 else
                     _loggingService.Info("No XPath changes detected so not saving");
@@ -366,7 +352,7 @@ namespace SHAutomation.Core.AutomationElements
 
             return element?.FrameworkAutomationElement != null ? (SHAutomationElement)element : null;
         }
-       
+
         private SHAutomationElement FindFirstByXPath(List<string> xpath, TimeSpan spinWaitTimeout)
         {
             SHAutomationElement validXpath = null;

--- a/src/SHAutomation.Core/Caching/CacheService.cs
+++ b/src/SHAutomation.Core/Caching/CacheService.cs
@@ -96,7 +96,7 @@ namespace SHAutomation.Core.Caching
                         {
                             _loggingService.Warn("Encountered issue performing Redis StringSet so retrying");
                             _loggingService.Warn(ex.Message);
-                            _database.StringSet(key, value);
+                            _database.StringSet(key, value, expiry: RedisManager.KeyExpiry.HasValue ? RedisManager.KeyExpiry.Value : (TimeSpan?)null);
 
                         }
                         else

--- a/src/SHAutomation.Core/Classes/ConfigFile.cs
+++ b/src/SHAutomation.Core/Classes/ConfigFile.cs
@@ -10,5 +10,6 @@ namespace SHAutomation.Core.Classes
         public bool RedisUseSSL { get; set; }
         public string BranchMatchRegex { get; set; }
         public TimeSpan? KeyExpiry { get; set; }
+        public TimeSpan? UpdateExpiryIfTTLLessThan { get; set; }
     }
 }

--- a/src/SHAutomation.Core/Classes/ConfigFile.cs
+++ b/src/SHAutomation.Core/Classes/ConfigFile.cs
@@ -1,4 +1,6 @@
-﻿namespace SHAutomation.Core.Classes
+﻿using System;
+
+namespace SHAutomation.Core.Classes
 {
     public class ConfigFile
     {
@@ -7,5 +9,6 @@
         public int RedisPort { get; set; }
         public bool RedisUseSSL { get; set; }
         public string BranchMatchRegex { get; set; }
+        public TimeSpan? KeyExpiry { get; set; }
     }
 }

--- a/src/SHAutomation.Core/StaticClasses/RedisManager.cs
+++ b/src/SHAutomation.Core/StaticClasses/RedisManager.cs
@@ -18,6 +18,7 @@ namespace SHAutomation.Core.StaticClasses
         public static string Password { get; set; }
         public static int Port { get; set; }
         public static bool UseSSL { get; set; }
+        public static TimeSpan? KeyExpiry { get; set; }
 
         // In general, let StackExchange.Redis handle most reconnects, 
         // so limit the frequency of how often this will actually reconnect.

--- a/src/SHAutomation.Core/StaticClasses/RedisManager.cs
+++ b/src/SHAutomation.Core/StaticClasses/RedisManager.cs
@@ -20,6 +20,8 @@ namespace SHAutomation.Core.StaticClasses
         public static bool UseSSL { get; set; }
         public static TimeSpan? KeyExpiry { get; set; }
 
+        public static TimeSpan? UpdateExpiryIfTTLLessThan { get; set; }
+
         // In general, let StackExchange.Redis handle most reconnects, 
         // so limit the frequency of how often this will actually reconnect.
         public static TimeSpan ReconnectMinFrequency = TimeSpan.FromSeconds(60);

--- a/test/SHAutomation.Core.Tests/Integration/XPathTests.cs
+++ b/test/SHAutomation.Core.Tests/Integration/XPathTests.cs
@@ -20,7 +20,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
 
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
 
             IDatabase db = RedisManager.Connection.GetDatabase();
@@ -41,7 +41,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
 
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             IDatabase db = RedisManager.Connection.GetDatabase();
             db.KeyDelete(TestContext.TestName);
@@ -63,7 +63,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
 
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             IDatabase db = RedisManager.Connection.GetDatabase();
             db.KeyDelete(TestContext.TestName);
@@ -115,7 +115,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
 
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             var cacheServiceMock = new Mock<ICacheService>();
             cacheServiceMock.Setup(x => x.GetCacheValue(It.IsAny<string>(), It.IsAny<string>()));
@@ -136,7 +136,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
 
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             var cacheServiceMock = new Mock<ICacheService>();
             cacheServiceMock.Setup(x => x.GetCacheValue(It.IsAny<string>(), It.IsAny<string>()));
@@ -163,7 +163,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
 
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             IDatabase db = RedisManager.Connection.GetDatabase();
             db.KeyDelete(TestContext.TestName);
@@ -179,7 +179,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
 
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             IDatabase db = RedisManager.Connection.GetDatabase();
             db.KeyDelete(TestContext.TestName);
@@ -208,7 +208,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
 
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             IDatabase db = RedisManager.Connection.GetDatabase();
             db.KeyDelete(TestContext.TestName);
@@ -224,12 +224,32 @@ namespace SHAutomation.Core.Tests.Integration
 
         }
 
+
+        [TestMethod]
+        public void KeyExpiryIsSetOnRecordWhenSet_SetXPathCache_BeTrue()
+        {
+
+            var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+
+            RedisManager.KeyExpiry = TimeSpan.FromMinutes(5);
+
+            IDatabase db = RedisManager.Connection.GetDatabase();
+
+            window.XPathList.Add((identifier: "KeyExpTest", property: "AutomationId", xpath: "XPATH"));
+            window.SaveXPathCache(TestContext.TestName);
+
+            var record = db.StringGetWithExpiry(TestContext.TestName);
+            record.Expiry.Should().NotBeNull();
+
+        }
+
         [TestMethod]
         public void XPathIsEmptyCollectionWhenNoCacheHit_GetXPathCache_BeTrue()
         {
 
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             window.GetXPathCache(TestContext.TestName);
 
@@ -292,7 +312,7 @@ namespace SHAutomation.Core.Tests.Integration
         {
 
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             Environment.SetEnvironmentVariable("Build_SourceBranchName", "8.25");
 
@@ -310,7 +330,7 @@ namespace SHAutomation.Core.Tests.Integration
         public void SavesXPathWithoutIterationName_SaveXPathCache_BeTrue()
         {
             var frameworkAutomationElementMock = new Mock<FrameworkAutomationElementBase>();
-            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(System.IO.Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
+            var window = new Window(frameworkAutomationElementMock.Object, Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "shautomation.json"));
 
             Environment.SetEnvironmentVariable("Build_SourceBranchName", "master");
 


### PR DESCRIPTION
Added the ability to specify KeyExpiry on RedisManager, this can also be set on the passed in config file. KeyExpiry is a TimeSpan and will let Redis automatically remove old keys once the expiry is breached.